### PR TITLE
Generate Table Of Contents and add it to index page

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "gulpfile.js",
   "readmeFilename": "README.markdown",
   "devDependencies": {
+    "cheerio": "^0.19.0",
     "del": "^1.2.0",
     "gh-pages": "^0.3.1",
     "gulp": "^3.9.0",

--- a/src/templates/index.jade
+++ b/src/templates/index.jade
@@ -5,6 +5,17 @@ html(lang="sv")
     title WebbRaket
     link(rel="stylesheet", href="css/main.css")
   body
+    h1 Innehållsförteckning
+    ol
+      each h1 in toc
+        li
+          a(href="##{h1.id}")= h1.name
+          ol
+            each h2 in h1.children
+              li
+                a(href="##{h2.id}")= h2.name
+
+
     != body
     script(src="js/main.js")
-    
+


### PR DESCRIPTION
Skapar en ny task `toc` som markeras som en dependency till `chapters`. Tasken `toc` genererar en table of contents-fil och sparar den i  `tmp/toc.json`. Hela `.tmp`-mappen är gitignore:ad och behöver därmed aldrig rensas av skriptet. Vi skriver över samma fil hela tiden. Innehållet av `toc.json` ges sedan som variabel så att `temlates/index.jade` har tillgång till den.
