### PR TITLE
Generate table of contents and add it to the top of the page

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -62,28 +62,24 @@ gulp.task('toc', function() {
     .pipe(concat('toc.json'))
     .pipe(insert.transform(function(contents) {
       var $ = cheerio.load(contents);
-      var h1s = $('h1');
-      var toc = h1s.toArray().map(function(h1) {
-        var $h1 = $('#' + h1.attribs.id);
+      var toc = $('h1').map(function(i, h1) {
         return {
-          id:   h1.attribs.id,
-          name: $h1.text(),
-          children: $h1.nextUntil('h1', 'h2').toArray().map(function(h2) {
-            var $h2 = $('#' + h2.attribs.id);
+          id:   $(h1).attr('id'),
+          name: $(h1).text(),
+          children: $(this).nextUntil('h1', 'h2').map(function(i, h2) {
             return {
-              id:   h2.attribs.id,
-              name: $h2.text(),
-              children: $h2.nextUntil('h2', 'h3').toArray().map(function(h3) {
-                var $h3 = $('#' + h3.attribs.id);
+              id:   $(this).attr('id'),
+              name: $(this).text(),
+              children: $(this).nextUntil('h2', 'h3').map(function(i, h3) {
                 return {
-                  id:   h3.attribs.id,
-                  name: $h3.text()
+                  id:   $(this).attr('id'),
+                  name: $(this).text()
                 };
-              })
+              }).get()
             }
-          })
+          }).get()
         }
-      });
+      }).get();
       return JSON.stringify(toc);
     }))
     .pipe(gulp.dest('tmp'));

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "gulpfile.js",
   "readmeFilename": "README.markdown",
   "devDependencies": {
+    "cheerio": "^0.19.0",
     "del": "^1.2.0",
     "gh-pages": "^0.3.1",
     "gulp": "^3.9.0",

--- a/src/templates/index.jade
+++ b/src/templates/index.jade
@@ -5,6 +5,17 @@ html(lang="sv")
     title WebbRaket
     link(rel="stylesheet", href="css/main.css")
   body
+    h1 Innehållsförteckning
+    ol
+      each h1 in toc
+        li
+          a(href="##{h1.id}")= h1.name
+          ol
+            each h2 in h1.children
+              li
+                a(href="##{h2.id}")= h2.name
+
+
     != body
     script(src="js/main.js")
-    
+


### PR DESCRIPTION
Skapar en ny task `toc` som markeras som en dependency till `chapters`. Tasken `toc` genererar en table of contents-fil och sparar den i  `tmp/toc.json`. Hela `.tmp`-mappen är gitignore:ad och behöver därmed aldrig rensas av skriptet. Vi skriver över samma fil hela tiden. Innehållet av `toc.json` ges sedan som variabel så att `templates/index.jade` har tillgång till den och kan rendera toc:en till slutgiltiga `index.html`-filen.
