### PR TITLE
Ta bort duplicerade >-tecken

### DIFF
--- a/src/chapters/01 Intro/02-quickstart.md
+++ b/src/chapters/01 Intro/02-quickstart.md
@@ -51,7 +51,7 @@ En fil är bara en mängd arbiträr men strukturerad data. Program följer olika
 Så hur vet operativsystemet vilken konvention den ska applicera? Tänk tillbaka på tidigare diskussion om att ett programs enda uppgift är att transformera input till output. Om ett program är specialiserat på att transformera en viss typ av input till en viss typ av output --- då är det en utmärkt kandidat för att vara en explicit konvention. Innehållet i en fil är alltså input (texten) och ett given program är alltså transformationsprocessen (konventionen).
 
 Låt oss formulera det i andra ord. En fil innehåller egentligen bara strukturerad råtext (egentligen: data). När denna fil med strukturerad råtext sedan öppnas med det program den var ämnad att öppnas i, kommer denna till synes mumbo jumbo av text helt plötsligt spela sin roll.
-> 
+
 > Prova själv genom att öppna t.ex. en .jpeg-fil i en vanlig texteditor (såsom Notepad eller TextEdit).
 
 Egentligen kan vi slänga på vilken filändelse (alltså t.ex. .tex, .doc, .pdf, .jpg, etc.) på vilken fil som helst. Den spelar ingen roll för själva innehållet i filen. Så länge vi öppnar filen med det avsedda programmet (och så länge det avsedda programmet tillåter oss att forcera det att öppna filer med "fel" filändelse) så kommer allt fungera precis som vanligt.

--- a/src/chapters/01 Intro/03-arkitektur.md
+++ b/src/chapters/01 Intro/03-arkitektur.md
@@ -63,7 +63,7 @@ Kommer snart...
 ### Klient-server-arkitektur
 
 Innan vi kan gå djupare in på varför vi **inte** kan utföra komplex logik i html så behöver vi lära oss lite om ansvarsområden för [klienter och servrar][0]. Vi har tidigare i detta kapitel uttryckt oss i bemärkelsen att en "server serverar en fil". Om vi är ännu mer explicita skulle vi kunna säga att en server severar en fil som en klient konsumerar.
-> 
+
 > En server _servererar_ resurser som _konsumeras_ av klienter. 
 
 Vad i hela friden menar vi med det? Vem är servern? Vem är klienten? Vad är en resurs? Detta är förstås generella termer som kan anta många skepnader. Men i de flesta av fall är din webbläsare klienten. Klienten är den som konsumerar. Klienten är den som blir serverad en HTML-sida. Klienten ansvarar själv för att rendera sidan. Såsom vi tidigare diskuterat. Webbläsaren (klienten) är ett program som är expert HTML-konventionen. Så när webbläsaren tar emot ett dokument som följer konventionen HTML så kan den utan problem rendera den visuella representationen av det dokumentet. Oavsett om du använder din webbläsare för att öppna www.google.com eller en HTML-fil på din egen dator så är webbläsaren en klient.
@@ -81,7 +81,7 @@ Många tänker på mörka dundrande hallar fyllda med korridorer av monstermaski
 ### Request-response
 
 Internet bygger på en modell som vi kan kalla för request-response-modellen. Ett "request" är en förfrågan, och ett "response" är ett svar. Vi vet ju nu att en servers uppgift är att servera klient med resurser. Men mer specifikt så serverar en server ett (passande) response till en klient, när denne klient skickar ett request. Vi säger passande eftersom reponse:et förstås beror på vilket request vi har skickat.
-> 
+
 > En server serverar ett response till den klient som skickar ett request.
 
 Det här låter kanske komplext men är egentligen väldigt enkelt. Låt oss se till det lite närmare. Aktörerna i denna klient-server-historia är alltså följande:

--- a/src/chapters/02 HTML/01-document-structure.md
+++ b/src/chapters/02 HTML/01-document-structure.md
@@ -5,7 +5,7 @@
 Innan vi ser till ett exempel behöver vi kort diskutera vad HTML är för någonting. Låt oss utföra en tankelek. Ponera att du, på datorn, skrivit ett dokument i _Microsoft Word_, _Pages_, _Open Office_ eller dylik ordbehandlare. Fundera kort över vad detta dokument består av. Vad innehåller det? Text? Jo, onekligen. Men mer exakt än så då? De flesta dokument innehåller någon kombination av rubriker, underrubriker och paragrafer. Men gräver vi djupare än så så hittar vi saker som citat, listor, understrykningar, fetstilsmarkeringar, kursivitet o.s.v.
 
 För att förstå hur HTML fungerar behöver vi egentligen bara förstå att vår ordbehandlare omöjligen kan komma ihåg vilka delar vi anser vara rubriker eller fetstilsmarkeringar om den inte någonstans sparar den informationen när vi först berättar det. Låt oss uttrycka oss på generellare form. Nästan alla dokument --- ovavsett typ --- består inte bara av text. De består av text som är tätt bunden till semantik. Varje del av texten spelar någon roll i helheten som inte nödvändigtvis behöver vara samma roll som någon annan del av samma text. En term som ofta används för att referera till detta förhållande mellan text och meta-information är [semantik][1]. Vi kommer framöver på många sätt prata om begreppet semantisk signifikans för att diskutera vad saker har för signifikans i en kontext.
-> 
+
 > Dokument består inte bara av rå text, utan rå text tätt med olika semantik.
 
 En paragraf är inte en paragraf om inte den som läser paragrafen kan urskilja och förstå att det är en paragraf den läser. Det är detta vi talar om när vi talar om semantisk signifikans. Utöver att vi som människor läser texten som paragrafen består av så "läser vi in" faktumet att det är ett avgränsatt område text --- i.e. en paragraf.
@@ -37,7 +37,7 @@ Vi har nu alltså klargjort att HTML bygger på en metfor om att alla dokument g
     <p>Paragraftexten här...</p>
 
 Ovan illustrerar alltså användandet av `p`-elementet, eller paragraf-elementet. Låt oss bena ut vad syntaxen är. Kom ihåg att ordet syntax handlar om _hur_ vi uttrycker någonting i ett visst språk. I fallet av HTML så är de tre första tecknena i ovan exempel, samt de fyra sista del av syntaxen i HTML. Övrigt är rå text.
-> 
+
 > HTML-element byggs upp av taggar.
 
 HTML-element består helt enkelt av någonting som vi referar till som taggar (tags). Element är alltså en komposition av taggar. Ett element kan komma i två former. Element kan alltså bestå av antingen...
@@ -63,7 +63,7 @@ För att kunna bygga hierarkiska trädstrukturer så behöver vi förstå att HT
 * Ett annat element
 
 När vi säger text så menar vi förstås även avsaknaden av text. Den tomma strängen. Så är det även tillåtet att ett element, som förväntar sig ett barn eller text, inte innehåller någonting. Med andra ord skulle elementet öppnas (starttagg) och sedan stängas på en gång (sluttagg).
-> 
+
 > Ett element kan antingen innehålla ett annat element eller text.
 
 Det är när vi börjar förstå att element kan innehålla andra element som vi verkligen börjar närma oss idéen om hierarkisk informationsrepresentation. Vi kan nu alltså börja uttrycka saker såsom:
@@ -101,7 +101,7 @@ Såsom exemplets text förtäljer har traditionella radbrytningar ingen effekt i
 ### Attribut
 
 Ett elements öppnande tag kan även innehålla attribut med värden. Attribut är i simpla termer egenskaper för ett givet element. Om vi t.ex. har en hyperlänk (`<a>`) kan vi använda oss av attributet `href` (hyper reference) för att denotera vart hyperlänken ska peka någonstans.
-> 
+
 > Attribut är egenskaper för en instans av ett element.
 
 För att t.ex. skapa länkar använder vi elementet `<a>`. För att sedan denotera vart länken ska peka ger vi attributet `href` ett värde. Detta värde tar formen av en URL. Beakta nedan exempel och fundera över användandet av attributet `href`.
@@ -117,7 +117,7 @@ Resultat
 Attribut kommer i två former där den vanligaste är nyckel-värde-par (key-value-pairs). Vi specificerar en nyckel och tilldelar den ett värde. Enligt syntaxen `nyckel="värde"`. Där ordet "nyckel" alltså ersätts med en nyckel som är tillåten för ett givet element. Och ordet "värde" ersätts med ett värde som är tillåtet för den givna nyckeln.
 
 Alla attribut (nycklar) är inte tillåtna på alla element. Alla värden är inte heller tillåtna på alla nycklar. Anledningen till detta är helt enkelt att attribut denoterar saker som ofta är specifika för just en given typ av element. I exemplet ovan använder vi t.ex. attributet `href` --- "hyper reference". En hyperreferens är logisk vid användandet av en länk eftersom en länk måste ha en målplats. En länk är inte en länk om den inte har någonstans att länka. Om vi däremot diskuterar en paragraf (`<p>`) så blir användandet av en hyperreferens helt meningslös. En paragraf är en paragraf av text, inte en länk. En paragraf ska inte hyperreferera någonstans. Det är inte logiskt.
-> 
+
 > Olika element tillåter olika attribut.
 
 Nu kanske du tänker att en paragraf ju måste gå att göra klickbar. Och det är helt sant. Men inte genom att klistra på ett hyperreferens-attribut på paragraf-taggen. Istället kan vi omsluta en del av paragrafens text i ett `<a>`-element. Kom ihåg --- vi kan nästla element i element!
@@ -195,7 +195,7 @@ När vi ändå är i farten med att försöka visualisera dokumenthierarkier. L�
         [empty]
 
 Detta med indentering leder oss även in på en meningsfull vana html-utvecklare respekterar.
-> 
+
 > Om en tag är ett barn till tag:en ovan, indentera ett steg.
 
 Notera alltså hur `title` är indenterad i relation till `head`, men hur `body`_inte _är indenterad i relation till `head.`
@@ -203,7 +203,7 @@ Notera alltså hur `title` är indenterad i relation till `head`, men hur `body`
 Återigen. Vi har inte bara slängt ihop ovan text lite hursomhelst. Utan det indenterade dokumentet är en representativ omskrivning av det tidigare diskuterade HTML-dokumentet. Återigen. Jämför denna indenterade version med den faktiska HTML-koden. Föräldra-barnrelationer defineras alltså nu genom indentering in. Syskonrelationer kan vi identifiera genom att hitta element som befinner sig på samma horisontella nivå under en och samma förälder.
 
 Detta leder oss in på en viktig poäng som du kanske redan förstått. När vi öppnar ett element måste vi stänga det innan vi stänger dess förälder.
-> 
+
 > Alla barnelement behöver stängas innan vi stänger föräldern.
 
 Icke-välformatterad HTML
@@ -268,7 +268,7 @@ Inkorrekt indentering
 ```
 
 Ett enkelt sätt att veta när man ska indentera --- alltså flytta en rad inåt, är följande minnesregel. Om vi öppnar ett element, ska allt som efterföljer indenteras, ända tills vi stängt elementet.
-> 
+
 > Alla barn till ett element ska indenteras ett "steg".
 
 Öppningstaggar och stängningstaggar ska alltså vara indenterade in till samma nivå. Om vi indenterar korrekt kommer det vara busenkelt att snabbt identifiera vilka element som är barn till vilka element. Vilka element som är syskon. Vart ett element stängs. Och så vidare, och så vidare.

--- a/src/chapters/02 HTML/02-common-elements.md
+++ b/src/chapters/02 HTML/02-common-elements.md
@@ -121,7 +121,7 @@ När vi kommer in på diskussionen om semantisk signifikans så kommer du förho
 När vi diskuterar tabeller så finns det egentligen fyra element som vi behöver lära oss. För att skapa en tabell börjar vi alltid med elementet `<table>`. Detta element enkapsulerar hela tabellen. Alla dess rader, kolumner och data.
 
 Innanför elementet `table` kan vi sedan placera ett valfritt antal element av typen `<tr>` (_table row_). Detta element skapar nya tabellrader. När vi skapar tabeller i HTML behöver vi alltså specificera kolumnerna i raderna och inte tvärtom. Syntaxen hade ju förstås likaväl kunnat fungera tvärtom men nu är fallet inte så.
-> 
+
 > I tabeller specificerar vi först raderna --- sedan kolumnerna. Aldrig tvärtom.
 
 Innanför elementet `tr` kan vi sedan placera ett valfritt antal element av typen `<td>` (_table data_. För att underlätta den mentala modellen kan du alltså tänka att elementet `td` skapar kolumner. Om vi använder `tr` för att skapa rader i tabellen så använder vi `td` för att skapa kolumner i en rad.

--- a/src/chapters/02 HTML/04-links.md
+++ b/src/chapters/02 HTML/04-links.md
@@ -41,7 +41,7 @@ Om vi i ett \*nix-baserat system vill nå en annan enhet, på samma sätt som vi
     /Volumes/MyOtherDisk
 
 För att sammanfatta absoluta och relativa sökvägar så vill vi understryka att det egentligen alltså är mycket enkelt. En relativ sökväg utgår ifrån den mapp där den som använder sökvägen befinner sig. En absolut sökväg utgår ifrån "roten" av den nuvarande enheten.
-> 
+
 > En relativ sökväg utgår ifrån nuvarande mapp. En absolut sökväg utgår ifrån någontings rot.
 
 Förhoppningsvis blir du lite förvirrad av att ovan uttrycker sig i termer av "någontings rot". Det finns olika typer av absoluta sökvägar när vi börjar tala om nätverk, och det är dessa vi ska se närmare på strax.
@@ -53,13 +53,13 @@ För att kunna diskutera sökvägar på internet behöver vi skapa oss en först
 Som du nu vet baseras webbsidor på standarden HTML. När vi med andra ord ber webbläsaren hämta en webbsida så anropar den en server som ger oss ett response som innehåller ett HTML-dokument. Vi har kort diskuterat request-response-modellen. Men vi har inte diskuterat de protokoll som möjliggör det. TCP, IP och HTTP bl.a. För att hålla oss fokuserade kommer vi inte att gräva i dessa. Men för att kunna intelligent angripa idéen om URL:er måste vi skapa oss en viss förståelse för protokollet HTTP.
 
 Men först, vad är ett protokoll? Kom ihåg att vi sa att en klient skickar ett request och en server svarar med ett response. Ett protokoll är helt enkelt en överenskommelse kring hur klienten och servern ska tala med varandra. När vi skickar saker över nätet så skickar vi de i fragmenterade paket och för att routrar, ISP:er och servrar ska veta vart våra paket är på väg, behöver vi protokoll. Här kommer TCP/IP in i bilden. För att servern ska kunna förstå vårt request och för att webbläsaren ska kunna förstå serverns response behöver vi protokollet HTTP (HyperText Transfer Protocol). Protokoll kan alltså liknas vid ett överenskommet språk emellan två parter.
-> 
+
 > För att två parter ska kunna kommunicera krävs ett överenskommet språk --- ett protokoll.
 
 Du har säkert kommit i kontakt med både protokollet `http` och den säkrare varianten `https`. Varje gång du skriver in en adress i webbläsaren så anger vi `http://`. Om vi inte gör det själva är webbläsarna idag tillräckligt smarta för att slänga in det protokollet åt oss.
 
 Nu när vi vet vad ett protokoll är --- vad är då en URL (Uniform Resource Locator)? En URL är helt enkelt en webbadress. Den pekar på en plats på internet där en webbresurs bör finnas.
-> 
+
 > En URL är en webbadress till en resurs på internet.
 
 När vi skriver in en webbadress i vår webbläsare så skriver vi alltså in en URL. Som tidigare nämnt så hjälper de flesta moderna webbläsare oss att skriva korrekta URL:er. En URL måste nämligen bl.a. innehålla ett protokoll. Var sig det är HTTP, HTTPS, FTP, SFTP o.s.v.
@@ -69,7 +69,7 @@ När vi skriver in en webbadress i vår webbläsare så skriver vi alltså in en
 Låt oss nu prata om sökvägar/webbadresser i HTML. Som tidigare nämnt så hanterar webbläsaren endast adresser i URL-format. Oavsett om det är en adress som pekar internt inom samma sida eller externt ut till en annan sida så behöver de vara i URL-format.
 
 En webbläsare behöver alltså ha en absolut sökväg i URL-formatet. Men när vi specificerar hyperlänkar i vår HTML. T.ex. genom att använda `<a>`-taggen, så behöver vi faktiskt inte alltid ange kompletta URL:er enligt URL-formatet. De fall då vi inte behöver göra det är alltså när vi refererar till resurser inom vår egen sida (domän). Om vi däremot vill referera till en resurs utanför vår domän så behöver vi ange en komplett adress i URL-formatet.
-> 
+
 > I HTML behöver vi inte ange protokoll när vi refererar till en URL inom samma domän.
 
 När vi refererar till en resurs inom vår egen domän så använder vi ett format som närmast liknar det \*nix-system använder. Förnim dig det vi tidigare diskuterat! Alltså slash för att denotera nästa mapp, punkt-punkt för att vandra en mapp upp i hierarkin, och en initial slash för att denotera roten.
@@ -102,7 +102,7 @@ Inte riktigt vad vi menade förstås. Det korrekta sättet att skapa ovan URL ä
 ### Ankare
 
 En typ av länkar vi ännu inte pratat om är ankare. Ankare är ett sätt att länka till en specifik del av en sida. Föreställ dig en lång sida. Alltså en sida med mycket content där du kan scrolla långt. Ankare hjälper dig då att skapa länkar **inom samma sida**.
-> 
+
 > Ett ankare kan appliceras i slutet av vilken URL som helst.
 
 Ett ankare börjar med fyrkants-tecknet (hashtag) (`#`) och sedan vilken sträng som helst.
@@ -134,7 +134,7 @@ Om vi hade specificerat en URL såsom ovan, hade vi skickat användaren till ind
 Det finns en sak vi ännu inte pratat om vad gäller ankare. Nu vet vi hur man skapar en länk **till** ett ankare. Men vi har inte pratat om hur man skapar ett ankare som man kan skickas till på en sida. Tidigare så använde vi exemplet `#my_anchor`, men vart hamnar användaren när den klickar på ankaret? Vart är "målet" för detta ankare specificerat?
 
 Egentligen är det ganska enkelt. En länk till ett ankare specificeras där vi kan ange en URL, och ett mål för ett ankare specificeras i vilket element som helst, under attributet ID.
-> 
+
 > Ankare pekar på egenskapen `id` i element.
 
 Låt oss se till ett exempel.

--- a/src/chapters/02 HTML/10-doctypes.md
+++ b/src/chapters/02 HTML/10-doctypes.md
@@ -38,7 +38,7 @@ Och i kontexten av ett HTML-dokument skulle det se ut som följande...
     </html>
 
 Om du inte har en medveten anledning till att använda någonting annat än HTML5, så hävdar vi att det inte finns någon anledning att göra det. Med andra ord, så skulle vi uppmana dig till att antingen hålla dig till HTML5 eller läsa på mer om doctypes om du vill använda någon annan.
-> 
+
 > Håll dig till HTML5, alltså `<DOCTYPE html>`, så länge du inte har en annan medveten anledning.
 
 #### Äldre doctypes

--- a/src/chapters/03 CSS/01-intro.md
+++ b/src/chapters/03 CSS/01-intro.md
@@ -3,7 +3,7 @@
 CSS --- (Cascading StyleSheets) är stilmallar i praktiken används till att formge dokument. Formge färg, teckensnitt, positionering, justering, backgrunder, scroll, o.s.v. En enda CSS-mall kan styra tusentals dokument och det är då enkelt att ändra formateringen genom att det bara i CSS-mallen.
 
 CSS har tagit HTML ett steg längre och möjliggjort formateringar och effekter som inte fanns i HTML standarden. En av fördelarna med CSS är att flera mallar kan användas och de har då företräde inbördes så att en "huvudmall" med de övergripande formateringarna kan ersättas på en lägre nivå av en "lokal mall" som då gäller före huvudmallen. Det är detta som åsyftas när man säger att css är `cascading`.
-> 
+
 > Med css kan vi separera innehåll och presentation.
 
 CSS är ett initiativ till att separera **innehåll** och **presentation**. Att definiera allt relaterat till presentation i en extern mall har många fördelar. Bland annat att:

--- a/src/chapters/03 CSS/02-syntax-och-struktur.md
+++ b/src/chapters/03 CSS/02-syntax-och-struktur.md
@@ -5,7 +5,7 @@ För att enklare förstå hur CSS hanteras, föreställ dig att webbläsaren bes
 Även om ovanstående exempel är orimligt oseriöst är poängen att rendering av en webbsida (metaforiskt) sker i olika "pass". Där det första är att få ut resultatet av HTML:en på skärmen, och det andra att visuellt ändra på resultatet av HTML:en enligt det som definierats i CSS-filen. Du kommer upptäcka att det finns fler "pass" (och att ordningen kan variera) när vi kommer till JavaScript, men det lämnar vi för nu.
 
 Varför är det då viktigt att förstå att CSS kommer i det "andra passet"? Jo, eftersom det är viktigt att förstå att CSS _appliceras_ på ett befintligt dokument. Med andra ord, ett CSS-dokument är i sig helt meningslöst. Eftersom ett CSS-dokument då appliceras på ett HTML-dokument så måste varje CSS-regel veta _vad_ den ska appliceras på. Och det är här `selectors` kommer in i bilden. Låt oss se till ett exempel.
-> 
+
 > En css-`selector` definierar vilka html-`element` som ska påverkas av en viss effekt.
 
 CSS-selector för HTML-element
@@ -43,7 +43,7 @@ Hur ska vi nu tänka kring det här? De viktigaste sakerna att poängtera är:
 * _Rad 5_ i html-dokumentet är det som gör att det som säger åt HTML-ninjorna att de behöver hämta CSS-ninjorna och att de ska läsa filen `main.css`.
 * _Rad 1_ i css-dokumentet är en `selector` vars `target` är `<body>`-elementet. Det betyder att allt mellan följande [måsvingar][0] (`{...}`) kommer att appliceras på _alla_ `<body>`-element i html-dokumentet. Nu bör det ju förstås bara finnas ett body-element men förhoppningsvis har du redan förstått att vi hade kunnat välja vilket annat html-element som helst.
 * _Rad 2 och 5_ i css-dokumentet är faktiskt css-`deklarationer`. Det är de som således bestämmer vilken visuell effekt som ska appliceras på just den selector vi definierat.
-> 
+
 > En css-`selector` kan vara vilket html-`element` som helst.
 
 Låt oss se det rent generellt. Syntaxen är alltså som följande.
@@ -55,7 +55,7 @@ CSS-syntax uttryckt generellt
     }
 
 Så, låt oss uttrycka syntaxen för `deklarationer` i ord: En css-`deklaration` består av en `egenskap` (även kallat: property, nyckel, key), följt av ett kolon (`:`) som fungerar som en avgränsare mellan nyckeln och värdet. Vidare följt av det faktiska `värdet` (som kan ges i en mängd olika format, såsom exempelvis `left`, `-32px`, `233%` eller `light`, beroende på vilken egenskap vi sätter värdet för). Slutligen anger vi ett semikolon (`;`) för att terminera raden. Det sistnämnda gör det möjligt att skriva flera deklarationer på samma rad (vilket dock oftast gör filen väldigt svårläslig).
-> 
+
 > En css-`deklaration` består av en `property` (även kallat: nyckel, key, egenskap), ett kolon (`:`), ett `värde` och slutligen ett semikolon (`;`).
 
 ### Exempel på selectors genom klass och ID

--- a/src/chapters/03 CSS/07-positionering.md
+++ b/src/chapters/03 CSS/07-positionering.md
@@ -11,7 +11,7 @@ Om vi inte anger någonting annat så är alla element statiskt placerade. Det �
 Om du inte anger någonting annat, kommer element att positioneras statiskt. Alltså följa sin naturliga plats i dokumentet.
 
 Det är viktigt att uppmärksamma att ett statiskt element på de (tänk dig en sida som ett koordinatsystem) koordinaterna `{0,0}`, omöjliggör att ett statiskt placerat syskon också placeras på `{0,0}`. Med andra ord tar statiskt placerade element upp plats och således kan syskon inte ligga på varandra utan placeras istället under (om de är [block-level element][0]) eller bredvid (om de är [inline-level element][1]) varandra.
-> 
+
 > Statiska element tar upp plats
 
 Att ett statiskt element inte kan placeras på ett annat element gäller förstås bara element som är syskon. Ett elements barn placeras förstås naturligt "innuti" förälderelementet.

--- a/src/chapters/04 JS/03-variabler.md
+++ b/src/chapters/04 JS/03-variabler.md
@@ -5,7 +5,7 @@ Eftersom JavaScript, som namnet antyder, är ett skriptspråk har vi tillgång t
 ### Vad är variabler?
 
 Variabler kan ses som en arbiträr box, av arbiträr storlek, där vi kan placera ett stycke, och endast ett stycke, arbiträr data. Tänk på det en stund. Låt oss formulera om samma sak. En variabel är en pekare mot en arbiträr plats i minnet, av arbiträr storlek, som innehåller arbiträr data. Det är lite närmare sanningen men fortfarande en metafor.
-> 
+
 > Variabler kan ses som en arbiträr box, av arbiträr storlek, där vi kan placera ett och endast ett stycke arbiträr data.
 
 Så hur deklarerar vi då en variabel? Låt oss se till ett exempel.
@@ -32,12 +32,12 @@ Deklarering och tilldelning
 Notera alltså att ovan exempel illustrerar att det är fullt möjligt att först deklarera en variabel och sedan tilldela den ett värde, i två steg. Detta kommer sig av den enkla anledningen att tilldelning och deklaration är två olika saker.
 
 **Deklaration**
-> 
+
 > Att säga att någonting _existerar_
 > (`var foo;`)
 
 **Tilldelning**
-> 
+
 > Att säga vad någonting _innehåller_
 > (`foo = "bar";`)
 
@@ -96,7 +96,7 @@ Tilldelning i programmering
     var d = a + b + c;    // d => 10
 
 Läs ovan, rad för rad, och fundera över varför det resultat som sparas i variabeln blir det som visas i kommentaren till höger.
-> 
+
 > När vi pratar om programmering är det lättare att tänka att vi "räknar ut värden och lägger resultaten i boxar".
 
 

--- a/src/chapters/04 JS/04-funktioner.md
+++ b/src/chapters/04 JS/04-funktioner.md
@@ -43,7 +43,7 @@ Låt oss uttrycka samma sak i matematik för att skapa ytterligare förståelse 
     F(F(1,F(1,1), 4) = 7
 
 Notera alltså att vi kan skicka resultatet av en funktion som parameter (input) till en annan funktion. Precis som i matematik så måste den innersta beräkningen utföras först innan vi kan utföra den yttre.
-> 
+
 > Precis som i matematik behöver det innersta uttrycket räknas ut först innan vi kan fortsätta "utåt".
 
 ### Olika sätt att deklarera funktioner

--- a/src/chapters/04 JS/05-dom.md
+++ b/src/chapters/04 JS/05-dom.md
@@ -74,7 +74,7 @@ Två
 </figure>
 
 Ok, nu kanske det krävs en liten förklaring. Om vi som i första exemplet hämtar med id då vet vi att vi endast får ett objekt tillbaka. I andra exemplet ovan ber vi om objekten med hjälp av tagnamnet och därför returneras dessa i en array. Med andra ord: när vi hämtar ett element genom ett ID kan vi alltid vara hundra på att det bara finns ett (eftersom ett ID endast får förekomma en gång i ett HTML-dokument). Men när vi söker element via tagnamn så kan vi omöjligen veta hur många instanser det finns av just den taggen. Således har man valt att låta `getElementsByTagName` returnera en array. Således är det även därför vi ovan använder bracket-notationen (`[x]`) för att arbeta med resultatet.
-> 
+
 > Se till att du förstår varför outputen i exemplet ovan blir som den blir innan du går vidare
 
 ### onload

--- a/src/chapters/06 jQuery/03-jqueryobjects.md
+++ b/src/chapters/06 jQuery/03-jqueryobjects.md
@@ -32,7 +32,7 @@ Med jQuery
     $('p').remove();
 
 Förhoppningsvis ser du nu styrkan! jQuery försökt att ta hand om den del vanligt återkommande problem och således försökt erbjuda oss utvecklare lite mindre huvudvärk. Nu kanske du redan fått huvudvärk flera gånger och känner den komma igen av att du behöver lära dig någonting nytt --- men lugn! När du väl fått kläm på syntaxen kommer jQuery hjälpa dig ofantligt, och förhoppningsvis kommer du vara arg på att vi försökte lära dig JavaScript först.
-> 
+
 > Förutom att jQuery gör det lättare för oss att utföra omständiga DOM-operationer gör den också att vi får mer webbläsarkompatibel kod, eftersom jQuery bygger på mycket "best practices".
 
 ### Vad är det?
@@ -46,7 +46,7 @@ Ta bort alla <p\>-element med jQuery
     $('p').remove();
 
 Det viktigaste vi måste förstå med ovan exempel, är att jQuery opererar på kollektioner av element och inte på enstaka element. Nu är det ju förstås så att det är fullt möjligt att vår kollektion endast innehåller ett element, men det är ändock en kollektion. För att dra en parallell så kan du tänka på hur JavaScript-metoden `document.getElementsByTagName()` fungerar. Namnet på metoden är pluraliserad eftersom även den returnerar en kollektion av `HTMLElement`. Detta alltså till skillnad ifrån `document.getElementById` som i alla fall returnerar max ett `HTMLElement`.
-> 
+
 > jQuery opererar på kollektioner av element.
 
 Men vad betyder då detta i praktiken? Jo, det betyder alltså att jQuery inte bryr sig om huruvida vi hittade ett eller flera element, när vi i ovan exempel anropar metoden `.remove()` så tar den alltså bort alla element i hela den kollektion den hade hittat. Låt oss se till ytterligare ett exempel för att illustrera detta:
@@ -73,15 +73,15 @@ Låt oss nu prata om vi hämtar element-kollektioner m.h.a. jQuery. Att hämta e
 Utan att snöa ner oss i svårare selektorer så kommer du förhoppningsvis ihåg de enklaste. De vanligaste css-selektorerna är:
 
 **` x`**
-> 
+
 > Element av typ x
 
 **`#x`**
-> 
+
 > Element med id x
 
 **`.x`**
-> 
+
 > Element med klassen x
 
 > Om du behöver läsa på om css-selektorer, läs mer i css-kapitlet!

--- a/src/chapters/06 jQuery/04-modify-elements.md
+++ b/src/chapters/06 jQuery/04-modify-elements.md
@@ -33,13 +33,13 @@ Vilket förändrar vår html så att vi nu har...
 Notera alltså att vi "blev av" med `<span>`-elementet. Samt att **båda** `<p>`-elementens inre html rensades.
 
 Men vänta nu, vad hände nu? Om du var uppmärksam så märkte du att när vi använde metoden `html()` för att **läsa** ifrån en element-kollektion så fick vi endast värdet ifrån det första elementet i kollektionen. Men när vi däremot använda `html()`-funktionen för att **skriva** så opererade vi på alla element i objekt-kollektionen. Vad händer nu egentligen?
-> 
+
 > Alla metoder på jQuery-objektet arbetar _inte alltid_ på alla element i kollektionen.
 
 ### Vilka metoder opererar över hela kollektionen?
 
 Oavsett vilket jQuery-metod vi använder är det alltså alltid viktigt att vara medveten om huruvida den arbetar på hela kollektionen eller ett specifikt element. En tumregel vi kan använda är att många av metoderna **läser ifrån det första** elementet i kollektionen och **skriver till alla** i kollektionen. Anropar vi alltså `html()` för att **läsa** kommer vi bara att få all inre html för det första elementet, medan om vi använder metoden till att skriva `html('something')` kommer vi förändra `innerHTML` för alla element i kollektionen.
-> 
+
 > En bra tumregel är att många jQuery-metoder läser ifrån första elementet i en objekt-kollektion, och skriver till alla.
 
 ### text()

--- a/src/chapters/08 PHP/03-debugging.md
+++ b/src/chapters/08 PHP/03-debugging.md
@@ -67,7 +67,7 @@ Ofta räcker det till och med med att skriva ut vad som helst till skärmen. Ibl
 När vi väl hittat felet är det bara att försöka söka rätt på en lösning. Om du inte spontant vet vad lösningen är så är internet ofta det bästa vapnet vi har. Försök att generalisera ditt problem lite utanför din specifika domän och ge dig ut i internetdjungeln. Alternativt, försök vara superspecifik. Om du t.ex. har en felkod --- sök efter felkoden. När vi väl får en förklaring till vad felet betyder kan det hända att det blir uppenbart hur vi ska fixa det.
 
 Det absolut viktigaste när vi väl har åtgärdat felet är förstås att **lära oss av våra misstag**. Fundera över det klassiska idiomet:
-> 
+
 > Fool me once, shame on you. Fool me twice, shame on me.
 
 Många gånger har vi inte resurser nog att faktiskt förstå varför ett fel inträffade. Om vi väl lyckats lösa det behöver vi istället tuta på. Men låt oss bara säga att om vi inte förstår varför ett fel inträffade så spelar det absolut ingen roll att vi har löst det. Det kommer att hända igen.


### PR DESCRIPTION
Denna commit tar bort `>`-tecken som jag av misstag råkade duplicera när jag automatiskt konverterade `jade`-filerna ifrån HTMLHunden till `markdown` som vi använder i Webbraket.
